### PR TITLE
Fix logo initial scale animation

### DIFF
--- a/components/Home/Hero.tsx
+++ b/components/Home/Hero.tsx
@@ -122,7 +122,7 @@ export class Hero extends React.Component<any> {
               <div className="font-sans text-3xl md:text-4xl mb-1">Luc Succès</div>
               <div className="text-sm md:text-md text-neutral-500">Coder. Designer. Startup founder</div>
             </div>
-            <div className={`${animationComplete ? 'mt-10' : ''} logo-container`}>
+            <div className={`${animationComplete ? 'mt-10' : ''} logo-container`} style={{ transform: 'scale(2)' }}>
               <Logo size="xlarge" animated={!animationComplete} />
             </div>
             <button


### PR DESCRIPTION
## Summary
- Fixed logo animation to start at the correct scale, preventing visual jump on page load
- Added inline `transform: scale(2)` style to logo container to ensure it renders at larger scale immediately
- Animation now smoothly transitions from scale(2) to scale(1) without the intermediate smaller scale appearance

## Test plan
- [ ] Load the homepage and verify logo starts at larger scale
- [ ] Confirm no visual jump or flash during initial load
- [ ] Verify smooth scale-down animation after logo drawing completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)